### PR TITLE
Add add-on product statistics endpoint for Pretix

### DIFF
--- a/app/config/base.yml
+++ b/app/config/base.yml
@@ -93,3 +93,8 @@ pretix_mapping:
 
   add_speaker:  # add speaker role to any other ticket (e.g. day tickets)
     - "XYZFG-1"  # Dean Doe
+
+# Add-on statistics configuration
+addon_statistics:
+  onsite_category_id: 0  # Pretix category ID for on-site tickets
+  tshirt_item_id: 0  # Pretix item ID for Conference T-Shirt add-on

--- a/app/main.py
+++ b/app/main.py
@@ -19,15 +19,22 @@ from app.routers.common import refresh_all
 async def lifespan(app: FastAPI):  # noqa: ARG001
     # Startup code
     refresh_all()
-    # Run Pretix validation if using Pretix backend
+    # Run Pretix validation and load add-on statistics if using Pretix backend
     try:
-        # make sure to use lazy import
         from app.pretix.validation import validate_pretix_mappings  # noqa: PLC0415
 
         validate_pretix_mappings()
     except Exception as e:
         logger = logging.getLogger("uvicorn.error")
         logger.error(f"Failed to validate Pretix mappings: {e}")
+
+    try:
+        from app.pretix.addon_stats import load_addon_statistics  # noqa: PLC0415
+
+        load_addon_statistics()
+    except Exception as e:
+        logger = logging.getLogger("uvicorn.error")
+        logger.error(f"Failed to load add-on statistics: {e}")
 
     logger = logging.getLogger("uvicorn.error")
     # Try to get the actual port from uvicorn server

--- a/app/middleware/interface.py
+++ b/app/middleware/interface.py
@@ -33,6 +33,8 @@ class Interface:
         self._valid_order_name_combo: dict = {}
         self.initial_data_loaded: bool = False
         self.categories: dict = {}  # For Pretix categories
+        self.addon_positions: list[dict] = []  # Add-on order positions (e.g., T-shirts)
+        self.item_variations: dict[int, str] = {}  # Variation ID → name mapping
         if self.in_dummy_mode:
             self.set_dummy_data()
 

--- a/app/pretix/addon_stats.py
+++ b/app/pretix/addon_stats.py
@@ -1,0 +1,143 @@
+"""Add-on product statistics for Pretix events.
+
+Fetches and caches add-on order position data from the Pretix API,
+then computes statistics about on-site ticket sales and T-shirt add-ons.
+"""
+
+from collections import Counter
+from http import HTTPStatus
+
+import requests
+
+from app import in_dummy_mode, interface, log
+from app.config import CONFIG
+from app.pretix.models import AddonStatistics, TShirtVariantCount
+from app.pretix.pretix_api import (
+    EVENT_SLUG,
+    ORGANIZER_SLUG,
+    PRETIX_BASE_URL,
+    headers,
+    response_is_not_ok,
+)
+
+
+def _fetch_all_pages(url: str, params: dict) -> list[dict]:
+    """Fetch all pages from a paginated Pretix API endpoint."""
+    collect = []
+    params = {**params, "page": 1}
+
+    while True:
+        log.info(f"fetching page:{params['page']} from {url}")
+        res = requests.get(url, headers=headers, params=params)
+        if res.status_code != HTTPStatus.OK:
+            response_is_not_ok(res)
+
+        res_j = res.json()
+        collect.extend(res_j["results"])
+
+        if res_j["next"]:
+            params["page"] += 1
+        else:
+            break
+
+    return collect
+
+
+def _fetch_item_variations(item_id: int) -> dict[int, str]:
+    """Fetch variation names for a specific item.
+
+    Returns a mapping of variation ID to human-readable name.
+    """
+    url = f"{PRETIX_BASE_URL}/organizers/{ORGANIZER_SLUG}/events/{EVENT_SLUG}/items/{item_id}/variations/"
+    results = _fetch_all_pages(url, {})
+
+    variations = {}
+    for var in results:
+        name = var["value"]
+        if isinstance(name, dict):
+            name = name.get("en", next(iter(name.values())))
+        variations[var["id"]] = name
+
+    return variations
+
+
+def _fetch_addon_positions(item_id: int) -> list[dict]:
+    """Fetch all order positions for a specific add-on item.
+
+    Returns minimal position data needed for statistics.
+    """
+    url = f"{PRETIX_BASE_URL}/organizers/{ORGANIZER_SLUG}/events/{EVENT_SLUG}/orderpositions/"
+    results = _fetch_all_pages(url, {"item": item_id})
+
+    positions = []
+    for pos in results:
+        if pos.get("canceled"):
+            continue
+        positions.append(
+            {
+                "id": pos["id"],
+                "order": pos["order"],
+                "positionid": pos["positionid"],
+                "item": pos["item"],
+                "variation": pos.get("variation"),
+                "addon_to": pos.get("addon_to"),
+            }
+        )
+
+    return positions
+
+
+def load_addon_statistics() -> None:
+    """Fetch add-on data from Pretix API and cache it in the Interface singleton.
+
+    Must be called after refresh_all() so that interface.all_sales and
+    interface.release_id_map are already populated.
+    """
+    if in_dummy_mode:
+        log.info("Skipping add-on statistics loading in dummy mode")
+        return
+
+    tshirt_item_id = CONFIG.addon_statistics.tshirt_item_id
+    log.info("Loading add-on statistics from Pretix API")
+
+    interface.item_variations = _fetch_item_variations(tshirt_item_id)
+    log.info(f"Loaded {len(interface.item_variations)} T-shirt variations")
+
+    interface.addon_positions = _fetch_addon_positions(tshirt_item_id)
+    log.info(f"Loaded {len(interface.addon_positions)} T-shirt add-on positions")
+
+
+def get_addon_statistics() -> AddonStatistics:
+    """Compute add-on statistics from cached data.
+
+    Returns metrics about on-site ticket sales and T-shirt add-on purchases.
+    """
+    onsite_category_id = CONFIG.addon_statistics.onsite_category_id
+
+    # Count on-site tickets from cached sales data
+    onsite_item_ids = {item_id for item_id, release in interface.release_id_map.items() if release.get("category_id") == onsite_category_id}
+    onsite_tickets = [sale for sale in interface.all_sales.values() if sale.get("item") in onsite_item_ids]
+    onsite_tickets_sold = len(onsite_tickets)
+
+    # Determine which on-site positions have a T-shirt add-on
+    # addon_to references the internal position ID of the parent
+    parent_ids_with_tshirt = {pos["addon_to"] for pos in interface.addon_positions if pos.get("addon_to") is not None}
+    tshirt_purchased = len(parent_ids_with_tshirt)
+    tshirt_not_purchased = onsite_tickets_sold - tshirt_purchased
+
+    # Count variants
+    variation_counts = Counter(pos["variation"] for pos in interface.addon_positions if pos.get("variation") is not None)
+    tshirt_variants = [
+        TShirtVariantCount(
+            variant_name=interface.item_variations.get(var_id, f"Unknown ({var_id})"),
+            count=count,
+        )
+        for var_id, count in sorted(variation_counts.items(), key=lambda x: x[1], reverse=True)
+    ]
+
+    return AddonStatistics(
+        onsite_tickets_sold=onsite_tickets_sold,
+        tshirt_purchased=tshirt_purchased,
+        tshirt_not_purchased=tshirt_not_purchased,
+        tshirt_variants=tshirt_variants,
+    )

--- a/app/pretix/models.py
+++ b/app/pretix/models.py
@@ -1,6 +1,6 @@
 """Pretix-specific models."""
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.models.base import BaseAttendee, BaseIsAnAttendee
 
@@ -45,3 +45,19 @@ class PretixIsAnAttendee(PretixAttendee, BaseIsAnAttendee):
     """Pretix validation response model."""
 
     pass
+
+
+class TShirtVariantCount(BaseModel):
+    """Count of a specific T-shirt variant."""
+
+    variant_name: str = Field(json_schema_extra={"example": "M", "description": "T-shirt size variant name"})
+    count: int = Field(json_schema_extra={"example": 42, "description": "Number of this variant purchased"})
+
+
+class AddonStatistics(BaseModel):
+    """Add-on product statistics for on-site attendees."""
+
+    onsite_tickets_sold: int = Field(json_schema_extra={"example": 200, "description": "Total on-site tickets sold in category"})
+    tshirt_purchased: int = Field(json_schema_extra={"example": 150, "description": "On-site tickets with T-shirt add-on"})
+    tshirt_not_purchased: int = Field(json_schema_extra={"example": 50, "description": "On-site tickets without T-shirt add-on"})
+    tshirt_variants: list[TShirtVariantCount] = Field(json_schema_extra={"description": "Breakdown of purchased T-shirt variants"})

--- a/app/pretix/router.py
+++ b/app/pretix/router.py
@@ -10,7 +10,8 @@ from app.routers.common import refresh_all
 from app.ticketing.backend import get_ticketing_backend
 from app.ticketing.utils import fuzzy_match_name
 
-from .models import PretixAttendee, PretixIsAnAttendee
+from .addon_stats import get_addon_statistics, load_addon_statistics
+from .models import AddonStatistics, PretixAttendee, PretixIsAnAttendee
 
 router = APIRouter(prefix="/tickets", tags=["Pretix Validation"])
 
@@ -96,6 +97,23 @@ async def validate_pretix_attendee(attendee: PretixAttendee, response: Response)
     res["is_attendee"] = False
     res["hint"] = f"No attendee named '{attendee.name}' found on order {attendee.order_id}"
     return res
+
+
+@router.get("/addon_statistics/", response_model=AddonStatistics, tags=["Pretix Statistics"])
+async def addon_statistics():
+    """Return add-on product statistics from cached data.
+
+    Provides metrics about on-site ticket sales and Conference T-Shirt add-on purchases.
+    Data is loaded on startup and can be refreshed via /tickets/refresh_addon_statistics/.
+    """
+    return get_addon_statistics()
+
+
+@router.get("/refresh_addon_statistics/", response_model=AddonStatistics, tags=["Pretix Statistics"])
+async def refresh_addon_statistics():
+    """Refresh add-on statistics cache from Pretix API and return updated data."""
+    load_addon_statistics()
+    return get_addon_statistics()
 
 
 def detailed_positive_result(item) -> dict[str, bool]:


### PR DESCRIPTION
Fetch and cache T-shirt add-on data from the Pretix API on startup, providing metrics about on-site ticket sales and T-shirt variant breakdown via GET /tickets/addon_statistics/ with explicit refresh support.