### PR TITLE
Auth: implement OAuth2/Keycloak JWT authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,10 @@ TITO_TOKEN="your_tito_api_token_here"
 ACCOUNT_SLUG="your_tito_account_slug"
 EVENT_SLUG="your_tito_event_slug"
 
+# OAuth2 / Keycloak authentication (required in production)
+# All /tickets/ endpoints require a valid JWT Bearer token when these are set.
+OIDC_ISSUER_URL="https://keycloak.example.com/realms/your-realm"
+OIDC_AUDIENCE="your-keycloak-client-id"
+
 # Optional: Test mode
 # FAKE_CHECK_IN_TEST_MODE=1

--- a/.env.pretix.example
+++ b/.env.pretix.example
@@ -7,5 +7,10 @@ PRETIX_BASE_URL="https://pretix.eu/api/v1"  # or your self-hosted instance like 
 PRETIX_ORGANIZER_SLUG="your_organizer_slug"
 PRETIX_EVENT_SLUG="your_event_slug"
 
+# OAuth2 / Keycloak authentication (required in production)
+# All /tickets/ endpoints require a valid JWT Bearer token when these are set.
+OIDC_ISSUER_URL="https://keycloak.example.com/realms/your-realm"
+OIDC_AUDIENCE="your-keycloak-client-id"
+
 # Optional: Override the ticketing backend (can also be set in app/config/base.yml)
 # TICKETING_BACKEND=pretix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,22 @@ none
   performance
 - **Refactored Codebase**: Significant refactoring for better maintainability and extensibility
 - **Enhanced Testing**: Fixed all existing tests and added new test cases for edge scenarios
+- **Authentication**: All /tickets/ endpoints now require valid JWT Bearer tokens when
+  authentication is enabled
 - **Bug Fixes**: Resolved all known issues
+
+### Added
+
+- **OAuth2 Authentication**: JWT validation via Keycloak or any OIDC-compliant provider
+  - Auth disabled by default when `OIDC_ISSUER_URL` is not set (dev-friendly)
+- `compose.override.yaml` for local development with Keycloak
+- `PyJWT[crypto]` dependency for RS256 JWT decoding
+
+### Changed
+
+- `docker compose up` starts Keycloak in dev mode via the override file
+- Production deployment uses `docker compose -f compose.yaml up -d` (no Keycloak)
+- `.env.example` and `.env.pretix.example` updated with OIDC variables
 
 ## [2.0.0] - 2025-08-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ uv pip install -e .
 
 # Create .env file with required credentials:
 
+# For all backends - OAuth2 / Keycloak authentication (required in production):
+# OIDC_ISSUER_URL="https://keycloak.example.com/realms/your-realm"
+# OIDC_AUDIENCE="your-keycloak-client-id"
+
 # For Tito (default):
 # TITO_TOKEN="your_secret_token"
 # ACCOUNT_SLUG="account_slug_from_tito"
@@ -40,8 +44,11 @@ uvicorn app.main:app --port 8080 --host "0.0.0.0"
 # OR with reload for development
 uvicorn app.main:app --reload
 
-# Run with Docker
-docker-compose up
+# Run with Docker (dev mode with Keycloak)
+docker compose up
+
+# Run on server (host nginx in front)
+docker compose -f compose.yaml up -d
 ```
 
 ### Testing
@@ -106,12 +113,23 @@ bump2version release --new-version 0.6.0dev1
    - Loads data from Tito API on startup (~30 seconds)
    - Supports refresh via `/tickets/refresh_all/` endpoint
 
-3. **Configuration** (`app/config/`)
+3. **Authentication** (`app/auth.py`)
+   - OAuth2 with Keycloak via JWT Bearer tokens
+   - OIDC discovery auto-resolves JWKS URI from issuer URL
+   - Validates JWT signature (via JWKS), expiration, issuer, audience, and sub
+   - Enabled when `OIDC_ISSUER_URL` env var is set; disabled when unset
+   - Applied to all `/tickets/` router endpoints via FastAPI dependency injection
+   - Healthcheck endpoints (`/`, `/healthcheck/alive`) remain public
+   - JWKS keys cached with 1-hour TTL, thread-safe
+   - Returns typed `TokenClaims` Pydantic model (or dev sentinel when disabled)
+   - Config loaded once at startup via `AuthConfig` dataclass
+
+4. **Configuration** (`app/config/`)
    - Uses OmegaConf for configuration management
    - Environment variables loaded from `.env` file
    - Test mode available via `FAKE_CHECK_IN_TEST_MODE=1`
 
-4. **Models** (`app/models/`)
+5. **Models** (`app/models/`)
    - Pydantic models for request/response validation
    - Strict type checking at runtime
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ PRETIX_EVENT_SLUG="your_event_slug"
 TICKETING_BACKEND=pretix
 ```
 
+### 2b. Configure Authentication (Optional)
+
+The API supports OAuth2/OIDC authentication via Keycloak (or any OIDC-compliant provider). All
+`/tickets/` endpoints require a valid JWT Bearer token when authentication is enabled. Healthcheck
+endpoints remain public.
+
+Add to your `.env` file:
+
+```bash
+OIDC_ISSUER_URL="https://keycloak.example.com/realms/your-realm"
+OIDC_AUDIENCE="your-keycloak-client-id"
+# Optional: override signing algorithm (default: RS256)
+# OIDC_ALGORITHMS="RS256"
+```
+
+When `OIDC_ISSUER_URL` is not set, authentication is disabled and all endpoints are open. This is
+the default for local development.
+
 ### 3. Configure Event Mapping (Pretix only)
 
 Edit `event_config.yml` to map your event's ticket categories and special roles:
@@ -162,23 +180,57 @@ pretix_mapping:
 uvicorn app.main:app --port 9898 --host "0.0.0.0"
 ```
 
-**Option B: Docker**
+**Option B: Docker (Development)**
+
+Running `docker compose up` loads `compose.override.yaml` automatically, which starts a local
+Keycloak instance alongside the API for OAuth2 development.
 
 ```bash
-# Set environment variables in .env file or export them
-export TITO_TOKEN="your_token"
-export ACCOUNT_SLUG="your_account"
-export EVENT_SLUG="your_event"
+# Starts fact_check_in + Keycloak (dev mode with hot-reload)
+docker compose up
+```
 
-# Build Docker image
-# Make sure to set `DOCKER_DEFAULT_PLATFORM` to match the server architecture (e.g. linux/amd64) if building on a different platform.
-# You can also configure the image name and tag with `IMAGE_NAME` and `IMAGE_TAG` environment variables.
+Keycloak quick setup for machine-to-machine access:
+
+1. Open `http://localhost:8080` and login with `admin / admin`.
+2. Create realm `fact-check-in`.
+3. Create API client (the token audience):
+   - Client ID: `fact-check-in-api`
+   - Protocol: `OpenID Connect`
+   - Client authentication: `Off`
+4. Create a caller client for each service that will call the API. Example:
+   - Client ID: `fact-check-in-caller`
+   - Protocol: `OpenID Connect`
+   - Client authentication: `On`
+   - Enable `Service account roles`
+   - Copy client secret from `Credentials`
+5. Add audience mapper so caller tokens include API audience:
+   - Create client scope `fact-check-in-api-access`
+   - Add mapper type `Audience` with included audience `fact-check-in-api`
+   - Assign that client scope to `fact-check-in-caller`
+
+Set API env vars in `.env`:
+
+```bash
+# Docker: http://keycloak:8080 | Prod: https://auth.yourdomain.com | Local tools: add 127.0.0.1 keycloak to /etc/hosts
+OIDC_ISSUER_URL=http://keycloak:8080/realms/fact-check-in
+OIDC_AUDIENCE="fact-check-in-api"
+```
+
+**Option C: Docker (Production)**
+
+In production, Keycloak should already be running (dedicated host or managed service). Use only
+`compose.yaml` to skip the dev override, and point your host nginx to port 9898.
+
+```bash
+# Build the image
+# Set DOCKER_DEFAULT_PLATFORM to match server arch if building cross-platform.
+# Configure image name/tag with IMAGE_NAME and IMAGE_TAG env vars.
 # Example: `DOCKER_DEFAULT_PLATFORM=linux/amd64 IMAGE_NAME=validation.api IMAGE_TAG=latest docker compose build`
 docker compose build
 
-# Start the container
-# You can also configure the container name with `CONTAINER_NAME` environment variable.
-docker compose up  # Use -d flag to run in detached mode
+# Start without the dev Keycloak override
+docker compose -f compose.yaml up -d
 ```
 
 **Note**: Startup takes ~30 seconds while loading ticket data.
@@ -190,6 +242,8 @@ docker compose up  # Use -d flag to run in detached mode
 
 ## Features
 
+- **OAuth2 Authentication**: JWT validation via Keycloak or any OIDC provider, with OIDC
+  auto-discovery, JWKS caching, and typed token claims
 - **Modular Backend Architecture**: Easily switch between ticketing systems or add new ones
 - **Dynamic Configuration**: Backend selection via environment variables or config files
 - **Smart Validation**:
@@ -215,10 +269,15 @@ ticketing platforms:
 
 ## API Endpoints
 
+All `/tickets/` endpoints require a valid Bearer token when authentication is enabled.
+
 - `POST /tickets/validate_name/` - Validate by ticket ID and name
 - `POST /tickets/validate_email/` - Validate by email
+- `POST /tickets/validate_attendee/` - Validate by order ID and name (Pretix)
+- `GET /tickets/ticket_types/` - List available ticket types
+- `GET /tickets/ticket_count/` - Count of tickets in cache
 - `GET /tickets/refresh_all/` - Force reload ticket data
-- `GET /healthcheck/alive` - Health check
+- `GET /healthcheck/alive` - Health check (public, no auth required)
 
 ## Development
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,218 @@
+"""OAuth2 authentication via Keycloak (or any OIDC provider).
+
+Validates JWT Bearer tokens using the provider's JWKS (JSON Web Key Set).
+OIDC discovery is used to automatically resolve the JWKS URI from the issuer URL.
+
+Configuration via environment variables:
+    OIDC_ISSUER_URL  - Keycloak realm URL, e.g.
+                       https://keycloak.example.com/realms/my-realm
+    OIDC_AUDIENCE    - Expected JWT audience (usually the Keycloak client ID).
+                       Defaults to "account" if not set.
+    OIDC_ALGORITHMS  - Comma-separated signing algorithms. Defaults to "RS256".
+
+When OIDC_ISSUER_URL is not set, authentication is completely disabled and all requests pass through
+with a dev-mode sentinel. This keeps local development simple.
+"""
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Annotated, Any
+
+import jwt
+import requests
+from cachetools import TTLCache, cached
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# -- Configuration ----------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AuthConfig:
+    """OIDC auth settings, loaded once from environment variables."""
+
+    issuer_url: str = ""
+    audience: str = "account"
+    algorithms: list[str] = field(default_factory=lambda: ["RS256"])
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.issuer_url)
+
+
+@lru_cache(maxsize=1)
+def get_auth_config() -> AuthConfig:
+    """Load auth config from env vars once and cache it forever."""
+    issuer = os.environ.get("OIDC_ISSUER_URL", "").rstrip("/")
+    audience = os.environ.get("OIDC_AUDIENCE", "account")
+    algorithms = [a.strip() for a in os.environ.get("OIDC_ALGORITHMS", "RS256").split(",")]
+    return AuthConfig(issuer_url=issuer, audience=audience, algorithms=algorithms)
+
+
+# -- Token claims model -----------------------------------------------------------
+
+
+class TokenClaims(BaseModel):
+    """Decoded and validated JWT claims.
+
+    Contains standard OIDC claims plus a flag indicating whether auth
+    was actually performed (disabled_auth=True in dev mode).
+    """
+
+    sub: str
+    iss: str = ""
+    aud: str | list[str] = ""
+    exp: int = 0
+    scope: str = ""
+    disabled_auth: bool = False
+
+
+#: Sentinel returned when auth is disabled (no OIDC_ISSUER_URL set).
+#: Route handlers can check ``claims.disabled_auth`` if they need to
+#: distinguish between authenticated and unauthenticated contexts.
+_DEV_CLAIMS = TokenClaims(sub="dev-user", disabled_auth=True)
+
+
+# -- OIDC / JWKS helpers ----------------------------------------------------------
+
+
+# auto_error=False so we can return a clear 401 instead of the default 403
+# when the Authorization header is missing entirely.
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+_cache_lock = threading.Lock()
+
+
+@cached(cache=TTLCache(maxsize=1, ttl=3600), lock=_cache_lock)  # type: ignore[misc]
+def _get_oidc_config(issuer_url: str) -> dict[str, Any]:
+    """Fetch and cache the OIDC discovery document.
+
+    Cached for 1 hour since OIDC metadata rarely changes. The lock
+    prevents concurrent cold-cache requests from duplicating the fetch.
+    """
+    discovery_url = f"{issuer_url.rstrip('/')}/.well-known/openid-configuration"
+    resp = requests.get(discovery_url, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@cached(cache=TTLCache(maxsize=1, ttl=3600), lock=_cache_lock)  # type: ignore[misc]
+def _get_jwks_client(jwks_uri: str) -> jwt.PyJWKClient:
+    """Create and cache a PyJWKClient for the given JWKS URI.
+
+    The client itself caches keys internally, and this outer cache
+    avoids re-creating the client object on every request.
+    """
+    return jwt.PyJWKClient(jwks_uri, cache_keys=True, lifespan=3600)
+
+
+# -- Token decoding ---------------------------------------------------------------
+
+
+def _decode_token(token: str, config: AuthConfig) -> TokenClaims:
+    """Decode and validate a JWT against the Keycloak OIDC provider.
+
+    Verifies signature (via JWKS), expiration, issuer, audience, and sub.
+    Raises HTTPException on any validation failure.
+    """
+    try:
+        oidc_config = _get_oidc_config(config.issuer_url)
+
+        jwks_uri = oidc_config.get("jwks_uri")
+        if not jwks_uri:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="OIDC discovery document missing jwks_uri",
+            )
+
+        jwks_client = _get_jwks_client(jwks_uri)
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=config.algorithms,
+            audience=config.audience,
+            issuer=config.issuer_url,
+            options={"require": ["exp", "iss", "aud", "sub"]},
+        )
+        return TokenClaims.model_validate(claims)
+
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+    except jwt.InvalidAudienceError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token audience",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+    except jwt.InvalidIssuerError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token issuer",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+    except jwt.MissingRequiredClaimError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing required claims",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+    except jwt.PyJWTError:
+        logger.debug("JWT validation failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or malformed token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+    except requests.RequestException:
+        logger.error("Failed to reach OIDC provider", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from None
+
+
+# -- FastAPI dependency ------------------------------------------------------------
+
+
+def verify_token(
+    credentials: Annotated[
+        HTTPAuthorizationCredentials | None,
+        Depends(_bearer_scheme),
+    ],
+) -> TokenClaims:
+    """FastAPI dependency that validates the OAuth2 Bearer token.
+
+    Returns a TokenClaims with the decoded JWT claims. When auth is
+    disabled (OIDC_ISSUER_URL not set), returns a dev-mode sentinel
+    with disabled_auth=True.
+
+    FastAPI runs sync dependencies in a threadpool, so the blocking
+    requests.get call for OIDC discovery (only on cold cache) does
+    not block the async event loop.
+    """
+    config = get_auth_config()
+
+    if not config.enabled:
+        return _DEV_CLAIMS
+
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return _decode_token(credentials.credentials, config)

--- a/app/auth.py
+++ b/app/auth.py
@@ -39,7 +39,7 @@ class AuthConfig:
     """OIDC auth settings, loaded once from environment variables."""
 
     issuer_url: str = ""
-    audience: str = "account"
+    audience: str = ""
     algorithms: list[str] = field(default_factory=lambda: ["RS256"])
 
     @property
@@ -49,10 +49,20 @@ class AuthConfig:
 
 @lru_cache(maxsize=1)
 def get_auth_config() -> AuthConfig:
-    """Load auth config from env vars once and cache it forever."""
+    """Load auth config from env vars once and cache it forever.
+
+    Raises ValueError at startup when auth is enabled but required settings are missing or invalid.
+    """
     issuer = os.environ.get("OIDC_ISSUER_URL", "").rstrip("/")
-    audience = os.environ.get("OIDC_AUDIENCE", "account")
-    algorithms = [a.strip() for a in os.environ.get("OIDC_ALGORITHMS", "RS256").split(",")]
+    audience = os.environ.get("OIDC_AUDIENCE", "")
+    algorithms = [a.strip() for a in os.environ.get("OIDC_ALGORITHMS", "RS256").split(",") if a.strip()]
+
+    if issuer:
+        if not audience:
+            raise ValueError("OIDC_AUDIENCE must be set explicitly when OIDC_ISSUER_URL is configured.")
+        if not algorithms:
+            raise ValueError("OIDC_ALGORITHMS must contain at least one valid algorithm when auth is enabled.")
+
     return AuthConfig(issuer_url=issuer, audience=audience, algorithms=algorithms)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,11 +4,12 @@ import sys
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI, Request, status
+from fastapi import Depends, FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from app.auth import verify_token
 from app.config import CONFIG
 from app.middleware import middleware
 from app.routers import routers
@@ -53,6 +54,17 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
     if os.environ.get("PORT"):
         port = os.environ.get("PORT")
 
+    from app.auth import get_auth_config
+
+    auth_config = get_auth_config()
+    if auth_config.enabled:
+        logger.info(
+            "OAuth2 authentication is ENABLED (issuer: %s)",
+            auth_config.issuer_url,
+        )
+    else:
+        logger.warning("OAuth2 authentication is DISABLED. Set OIDC_ISSUER_URL env var to enable")
+
     logger.info("\n" + "=" * 60)
     logger.info(f"🚀 {CONFIG.PROJECT_NAME} Ready!")
     logger.info("=" * 60)
@@ -67,8 +79,10 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
 app = FastAPI(title=CONFIG.PROJECT_NAME, middleware=middleware, lifespan=lifespan)
 
 # routers are dynamically collected in routers.__init__.py file
+# All router endpoints require a valid OAuth2 Bearer token when OIDC_ISSUER_URL is set.
+# Healthcheck endpoints defined directly on the app remain public.
 for router in sorted(routers, key=lambda x: x.router.tags[0]):
-    app.include_router(router.router)
+    app.include_router(router.router, dependencies=[Depends(verify_token)])
 
 
 # Report validation errors, see https://stackoverflow.com/a/62937228

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,0 +1,65 @@
+# compose.override.yaml - Development overrides (auto-loaded by docker compose)
+#
+# Starts Keycloak alongside the API for local OAuth2 development.
+# The API auto-reloads on code changes via volume mount.
+# This file is for development only. Do not use it in production.
+#
+# Usage:
+#   docker compose up              # starts both fact_check_in + keycloak
+#   docker compose up keycloak     # start only Keycloak
+#
+# Keycloak Admin Console:  http://localhost:8080
+#   User: admin / admin
+#
+# Minimal Keycloak setup:
+#   Realm: fact-check-in
+#   API client (audience): fact-check-in-api (client auth Off)
+#   Caller client: fact-check-in-caller (client auth On, service accounts enabled)
+#   Add audience mapper so caller tokens include aud=fact-check-in-api
+#
+# Then set OIDC_ISSUER_URL and OIDC_AUDIENCE in your .env file. Example:
+#   OIDC_ISSUER_URL=http://keycloak:8080/realms/fact-check-in
+#   OIDC_AUDIENCE=fact-check-in-api
+
+services:
+  fact_check_in:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - FAKE_CHECK_IN_TEST_MODE=${FAKE_CHECK_IN_TEST_MODE:-1}
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}
+      - OIDC_AUDIENCE=${OIDC_AUDIENCE:-}
+    volumes:
+      - ./app:/code/app
+      - ./tests:/code/tests
+      - ./event_config.yml:/code/event_config.yml:ro
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    command:
+      - /usr/local/bin/uv
+      - run
+      - uvicorn
+      - app.main:app
+      - --host=0.0.0.0
+      - --port=9898
+      - --reload
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.5.7
+    container_name: keycloak
+    command: start-dev
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HTTP_PORT: "8080"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200'"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 30s

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,6 @@ services:
     env_file:
       - .env
     environment:
-      # These will override values from .env file
       # Shell environment variables take precedence over .env file
       - TICKETING_BACKEND
       - TITO_TOKEN
@@ -18,6 +17,8 @@ services:
       - PRETIX_BASE_URL
       - PRETIX_ORGANIZER_SLUG
       - PRETIX_EVENT_SLUG
+      - OIDC_ISSUER_URL
+      - OIDC_AUDIENCE
       - FAKE_CHECK_IN_TEST_MODE
     volumes:
       # Mount event_config.yml for live updates without rebuilding

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,6 +129,24 @@ PRETIX_EVENT_SLUG="your_event_slug"
 TICKETING_BACKEND=pretix
 ```
 
+### 2b. Configure Authentication (Optional)
+
+The API supports OAuth2/OIDC authentication via Keycloak (or any OIDC-compliant provider). All
+`/tickets/` endpoints require a valid JWT Bearer token when authentication is enabled. Healthcheck
+endpoints remain public.
+
+Add to your `.env` file:
+
+```bash
+OIDC_ISSUER_URL="https://keycloak.example.com/realms/your-realm"
+OIDC_AUDIENCE="your-keycloak-client-id"
+# Optional: override signing algorithm (default: RS256)
+# OIDC_ALGORITHMS="RS256"
+```
+
+When `OIDC_ISSUER_URL` is not set, authentication is disabled and all endpoints are open. This is
+the default for local development.
+
 ### 3. Configure Event Mapping (Pretix only)
 
 Edit `event_config.yml` to map your event's ticket categories and special roles:
@@ -162,23 +180,57 @@ pretix_mapping:
 uvicorn app.main:app --port 9898 --host "0.0.0.0"
 ```
 
-**Option B: Docker**
+**Option B: Docker (Development)**
+
+Running `docker compose up` loads `compose.override.yaml` automatically, which starts a local
+Keycloak instance alongside the API for OAuth2 development.
 
 ```bash
-# Set environment variables in .env file or export them
-export TITO_TOKEN="your_token"
-export ACCOUNT_SLUG="your_account"
-export EVENT_SLUG="your_event"
+# Starts fact_check_in + Keycloak (dev mode with hot-reload)
+docker compose up
+```
 
-# Build Docker image
-# Make sure to set `DOCKER_DEFAULT_PLATFORM` to match the server architecture (e.g. linux/amd64) if building on a different platform.
-# You can also configure the image name and tag with `IMAGE_NAME` and `IMAGE_TAG` environment variables.
+Keycloak quick setup for machine-to-machine access:
+
+1. Open `http://localhost:8080` and login with `admin / admin`.
+2. Create realm `fact-check-in`.
+3. Create API client (the token audience):
+   - Client ID: `fact-check-in-api`
+   - Protocol: `OpenID Connect`
+   - Client authentication: `Off`
+4. Create a caller client for each service that will call the API. Example:
+   - Client ID: `fact-check-in-caller`
+   - Protocol: `OpenID Connect`
+   - Client authentication: `On`
+   - Enable `Service account roles`
+   - Copy client secret from `Credentials`
+5. Add audience mapper so caller tokens include API audience:
+   - Create client scope `fact-check-in-api-access`
+   - Add mapper type `Audience` with included audience `fact-check-in-api`
+   - Assign that client scope to `fact-check-in-caller`
+
+Set API env vars in `.env`:
+
+```bash
+# Docker: http://keycloak:8080 | Prod: https://auth.yourdomain.com | Local tools: add 127.0.0.1 keycloak to /etc/hosts
+OIDC_ISSUER_URL=http://keycloak:8080/realms/fact-check-in
+OIDC_AUDIENCE="fact-check-in-api"
+```
+
+**Option C: Docker (Production)**
+
+In production, Keycloak should already be running (dedicated host or managed service). Use only
+`compose.yaml` to skip the dev override, and point your host nginx to port 9898.
+
+```bash
+# Build the image
+# Set DOCKER_DEFAULT_PLATFORM to match server arch if building cross-platform.
+# Configure image name/tag with IMAGE_NAME and IMAGE_TAG env vars.
 # Example: `DOCKER_DEFAULT_PLATFORM=linux/amd64 IMAGE_NAME=validation.api IMAGE_TAG=latest docker compose build`
 docker compose build
 
-# Start the container
-# You can also configure the container name with `CONTAINER_NAME` environment variable.
-docker compose up  # Use -d flag to run in detached mode
+# Start without the dev Keycloak override
+docker compose -f compose.yaml up -d
 ```
 
 **Note**: Startup takes ~30 seconds while loading ticket data.
@@ -190,6 +242,8 @@ docker compose up  # Use -d flag to run in detached mode
 
 ## Features
 
+- **OAuth2 Authentication**: JWT validation via Keycloak or any OIDC provider, with OIDC
+  auto-discovery, JWKS caching, and typed token claims
 - **Modular Backend Architecture**: Easily switch between ticketing systems or add new ones
 - **Dynamic Configuration**: Backend selection via environment variables or config files
 - **Smart Validation**:
@@ -215,10 +269,15 @@ ticketing platforms:
 
 ## API Endpoints
 
+All `/tickets/` endpoints require a valid Bearer token when authentication is enabled.
+
 - `POST /tickets/validate_name/` - Validate by ticket ID and name
 - `POST /tickets/validate_email/` - Validate by email
+- `POST /tickets/validate_attendee/` - Validate by order ID and name (Pretix)
+- `GET /tickets/ticket_types/` - List available ticket types
+- `GET /tickets/ticket_count/` - Count of tickets in cache
 - `GET /tickets/refresh_all/` - Force reload ticket data
-- `GET /healthcheck/alive` - Health check
+- `GET /healthcheck/alive` - Health check (public, no auth required)
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mkdocs-material[imaging]>=9.7.6",
     "omegaconf>=2.3.0",
     "pydantic[email]>=2.12.5",
+    "PyJWT[crypto]>=2.10.0",
     "python-dotenv>=1.2.2",
     "requests>=2.33.1",
     "rich>=14.3.3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,23 @@ def _set_tito_for_unit_tests():
 
 
 @pytest.fixture(autouse=True)
-def reset_backend_cache():
+def _clear_oidc_env(monkeypatch):
+    """Ensure OIDC env vars are absent and auth config cache is reset.
+
+    Without clearing the lru_cache, a cached AuthConfig from a previous test
+    (e.g. test_auth.py's auth_client) persists and enables OAuth2 for later
+    tests that don't expect it.
+    """
+    from app.auth import get_auth_config
+
+    monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+    monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
+    monkeypatch.delenv("OIDC_ALGORITHMS", raising=False)
+    get_auth_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_backend_cache(monkeypatch):
     """Reset the backend cache before each test to ensure proper isolation."""
     from app import reset_interface
     from app.config import CONFIG
@@ -78,6 +94,13 @@ def reset_backend_cache():
 
     # Reset interface to ensure it uses the correct backend
     reset_interface(dummy_mode=True)
+
+    # reload_env() in app/config/__init__.py may override FAKE_CHECK_IN_TEST_MODE
+    # from .env at import time, leaving tito_api.in_dummy_mode as False (it is a
+    # module-level bool copy).  Force it to True so the Tito backend never
+    # attempts live API calls during tests.
+    monkeypatch.setattr("app.tito.tito_api.in_dummy_mode", True)
+    monkeypatch.setattr("app.in_dummy_mode", True)
 
     yield
 

--- a/tests/integration/test_pretix_live.py
+++ b/tests/integration/test_pretix_live.py
@@ -56,8 +56,20 @@ class TestPretixIntegration:
         # FAKE_CHECK_IN_TEST_MODE may be set by unit tests running in the same
         # pytest session, so we explicitly clear it here.
         env.pop("FAKE_CHECK_IN_TEST_MODE", None)
+        # Disable OAuth2 for integration tests - we only test Pretix functionality.
+        # app/config/__init__.py calls reload_env() which reads .env with
+        # load_dotenv(override=True), so env vars set here get overwritten.
+        # We launch a wrapper that clears OIDC_ISSUER_URL after app.config import
+        # (which triggers reload_env) but before the OIDC config is cached.
+        server_script = (
+            "import os; "
+            "import app.config; "  # triggers reload_env()
+            "os.environ.pop('OIDC_ISSUER_URL', None); "
+            "import uvicorn; "
+            "uvicorn.run('app.main:app', port=8002, host='127.0.0.1')"
+        )
         cls.server_process = subprocess.Popen(
-            [sys.executable, "-m", "uvicorn", "app.main:app", "--port", "8002", "--host", "127.0.0.1"],
+            [sys.executable, "-c", server_script],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -115,7 +115,7 @@ def auth_client(monkeypatch, jwks_response) -> Generator[TestClient]:
 
     jwks_uri = f"{ISSUER_URL}/protocol/openid-connect/certs"
     with (
-        patch("requests.get", side_effect=_mock_oidc_discovery(jwks_uri)),
+        patch("app.auth.requests.get", side_effect=_mock_oidc_discovery(jwks_uri)),
         patch.object(
             jwt.PyJWKClient,
             "fetch_data",
@@ -266,3 +266,42 @@ class TestOAuth2Disabled:
             headers={"Authorization": "Bearer some-token"},
         )
         assert response.status_code == 200  # noqa: PLR2004
+
+
+# -- Config validation tests --
+
+
+class TestAuthConfigValidation:
+    """Tests for startup validation of auth configuration."""
+
+    def test_missing_audience_raises(self, monkeypatch):
+        """Enabling auth without OIDC_AUDIENCE must fail at startup."""
+        monkeypatch.setenv("OIDC_ISSUER_URL", ISSUER_URL)
+        monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
+        _clear_auth_caches()
+        with pytest.raises(ValueError, match="OIDC_AUDIENCE must be set explicitly"):
+            from app.auth import get_auth_config
+
+            get_auth_config()
+
+    def test_empty_algorithms_raises(self, monkeypatch):
+        """Empty OIDC_ALGORITHMS with auth enabled must fail at startup."""
+        monkeypatch.setenv("OIDC_ISSUER_URL", ISSUER_URL)
+        monkeypatch.setenv("OIDC_AUDIENCE", AUDIENCE)
+        monkeypatch.setenv("OIDC_ALGORITHMS", "")
+        _clear_auth_caches()
+        with pytest.raises(ValueError, match="at least one valid algorithm"):
+            from app.auth import get_auth_config
+
+            get_auth_config()
+
+    def test_trailing_comma_algorithms_filtered(self, monkeypatch):
+        """Trailing commas in OIDC_ALGORITHMS should not produce empty entries."""
+        monkeypatch.setenv("OIDC_ISSUER_URL", ISSUER_URL)
+        monkeypatch.setenv("OIDC_AUDIENCE", AUDIENCE)
+        monkeypatch.setenv("OIDC_ALGORITHMS", "RS256,")
+        _clear_auth_caches()
+        from app.auth import get_auth_config
+
+        config = get_auth_config()
+        assert config.algorithms == ["RS256"]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,268 @@
+"""Tests for OAuth2/Keycloak authentication.
+
+Uses real RSA key pairs and mocked OIDC discovery / JWKS endpoints to verify JWT validation works
+correctly.
+"""
+
+import time
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.testclient import TestClient
+
+# -- RSA key fixtures --
+
+ISSUER_URL = "https://keycloak.test/realms/test-realm"
+AUDIENCE = "test-client"
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    """Generate an RSA key pair for signing test JWTs."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    return private_key, private_key.public_key()
+
+
+@pytest.fixture(scope="module")
+def jwks_response(rsa_keypair):
+    """Build a JWKS response containing the test public key."""
+    _, public_key = rsa_keypair
+    jwk = jwt.algorithms.RSAAlgorithm.to_jwk(public_key, as_dict=True)
+    jwk["kid"] = "test-key-id"
+    jwk["use"] = "sig"
+    jwk["alg"] = "RS256"
+    return {"keys": [jwk]}
+
+
+def _make_token(  # noqa: PLR0913
+    rsa_keypair,
+    *,
+    exp_offset: int = 3600,
+    issuer: str = ISSUER_URL,
+    audience: str = AUDIENCE,
+    include_sub: bool = True,
+    extra_claims: dict | None = None,
+) -> str:
+    """Create a signed JWT with the given claims."""
+    private_key, _ = rsa_keypair
+    now = int(time.time())
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "exp": now + exp_offset,
+        "iat": now,
+        **({"sub": "test-user-id"} if include_sub else {}),
+        **(extra_claims or {}),
+    }
+    return jwt.encode(
+        payload,
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "test-key-id"},
+    )
+
+
+def _mock_oidc_discovery(jwks_uri: str):
+    """Return a side_effect for requests.get that serves OIDC discovery."""
+    discovery_doc = {
+        "issuer": ISSUER_URL,
+        "jwks_uri": jwks_uri,
+        "authorization_endpoint": f"{ISSUER_URL}/protocol/openid-connect/auth",
+        "token_endpoint": f"{ISSUER_URL}/protocol/openid-connect/token",
+    }
+
+    def side_effect(url, **kwargs):  # noqa: ARG001
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = discovery_doc
+        return mock_resp
+
+    return side_effect
+
+
+def _clear_auth_caches():
+    """Clear all auth caches between tests."""
+    from app.auth import _get_jwks_client, _get_oidc_config, get_auth_config
+
+    _get_oidc_config.cache.clear()  # type: ignore[attr-defined]
+    _get_jwks_client.cache.clear()  # type: ignore[attr-defined]
+    get_auth_config.cache_clear()
+
+
+@pytest.fixture
+def auth_client(monkeypatch, jwks_response) -> Generator[TestClient]:
+    """Test client with Keycloak OAuth2 authentication enabled."""
+    from app.config import CONFIG
+
+    monkeypatch.setenv("TICKETING_BACKEND", "tito")
+    monkeypatch.setenv("OIDC_ISSUER_URL", ISSUER_URL)
+    monkeypatch.setenv("OIDC_AUDIENCE", AUDIENCE)
+    CONFIG["TICKETING_BACKEND"] = "tito"
+
+    _clear_auth_caches()
+
+    from app import reset_interface
+    from app.main import app
+
+    reset_interface(dummy_mode=True)
+
+    jwks_uri = f"{ISSUER_URL}/protocol/openid-connect/certs"
+    with (
+        patch("requests.get", side_effect=_mock_oidc_discovery(jwks_uri)),
+        patch.object(
+            jwt.PyJWKClient,
+            "fetch_data",
+            return_value=jwks_response,
+        ),
+    ):
+        yield TestClient(app)
+
+    _clear_auth_caches()
+
+
+@pytest.fixture
+def noauth_client(monkeypatch) -> Generator[TestClient]:
+    """Test client with authentication disabled (no OIDC config)."""
+    from app.config import CONFIG
+
+    monkeypatch.setenv("TICKETING_BACKEND", "tito")
+    monkeypatch.delenv("OIDC_ISSUER_URL", raising=False)
+    monkeypatch.delenv("OIDC_AUDIENCE", raising=False)
+    CONFIG["TICKETING_BACKEND"] = "tito"
+
+    _clear_auth_caches()
+
+    from app import reset_interface
+    from app.main import app
+
+    reset_interface(dummy_mode=True)
+    yield TestClient(app)
+
+    _clear_auth_caches()
+
+
+# -- Auth enabled tests --
+
+
+class TestOAuth2Enabled:
+    """Tests when OIDC_ISSUER_URL is set and auth is required."""
+
+    def test_valid_token_passes(self, auth_client, rsa_keypair):
+        token = _make_token(rsa_keypair)
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200  # noqa: PLR2004
+
+    def test_missing_token_returns_401(self, auth_client):
+        response = auth_client.get("/tickets/ticket_count/")
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Missing authentication credentials"
+
+    def test_expired_token_returns_401(self, auth_client, rsa_keypair):
+        token = _make_token(rsa_keypair, exp_offset=-3600)
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Token has expired"
+
+    def test_wrong_audience_returns_401(self, auth_client, rsa_keypair):
+        token = _make_token(rsa_keypair, audience="wrong-client")
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Invalid token audience"
+
+    def test_wrong_issuer_returns_401(self, auth_client, rsa_keypair):
+        token = _make_token(rsa_keypair, issuer="https://evil.example.com")
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Invalid token issuer"
+
+    def test_missing_sub_claim_returns_401(self, auth_client, rsa_keypair):
+        """Tokens without a 'sub' claim should be rejected."""
+        token = _make_token(rsa_keypair, include_sub=False)
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Token missing required claims"
+
+    def test_garbage_token_returns_401(self, auth_client):
+        response = auth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": "Bearer not-a-jwt"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+        assert response.json()["detail"] == "Invalid or malformed token"
+
+    def test_healthcheck_no_auth_required(self, auth_client):
+        """Healthcheck endpoints remain public even with auth enabled."""
+        response = auth_client.get("/healthcheck/alive")
+        assert response.status_code == 200  # noqa: PLR2004
+        assert response.json() == {"alive": True}
+
+    def test_root_no_auth_required(self, auth_client):
+        """Root endpoint remains public even with auth enabled."""
+        response = auth_client.get("/")
+        assert response.status_code == 200  # noqa: PLR2004
+        assert response.json() == {"alive": True}
+
+    def test_post_endpoint_requires_auth(self, auth_client):
+        """POST endpoints also require auth."""
+        response = auth_client.post(
+            "/tickets/validate_name/",
+            json={"ticket_id": "TEST123", "name": "Test User"},
+        )
+        assert response.status_code == 401  # noqa: PLR2004
+
+    def test_post_endpoint_with_auth(self, auth_client, rsa_keypair):
+        """POST endpoints work with valid auth."""
+        token = _make_token(rsa_keypair)
+        response = auth_client.post(
+            "/tickets/validate_name/",
+            json={"ticket_id": "TEST123", "name": "Test User"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        # Should not be 401 - the request is authenticated.
+        # It may be 404 (ticket not found) which is correct behavior.
+        assert response.status_code != 401  # noqa: PLR2004
+
+
+# -- Auth disabled tests --
+
+
+class TestOAuth2Disabled:
+    """Tests when OIDC_ISSUER_URL is not set and auth is disabled."""
+
+    def test_request_without_token_passes(self, noauth_client):
+        response = noauth_client.get("/tickets/ticket_count/")
+        assert response.status_code == 200  # noqa: PLR2004
+
+    def test_healthcheck_still_works(self, noauth_client):
+        response = noauth_client.get("/healthcheck/alive")
+        assert response.status_code == 200  # noqa: PLR2004
+
+    def test_request_with_token_still_passes(self, noauth_client):
+        """Providing a token when auth is disabled should not cause errors."""
+        response = noauth_client.get(
+            "/tickets/ticket_count/",
+            headers={"Authorization": "Bearer some-token"},
+        )
+        assert response.status_code == 200  # noqa: PLR2004

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
+]
+
+[[package]]
 name = "cssselect2"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -283,6 +336,7 @@ dependencies = [
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "omegaconf" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "rich" },
@@ -313,6 +367,7 @@ requires-dist = [
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7.6" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "rich", specifier = ">=14.3.3" },
@@ -793,6 +848,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add OAuth2 authentication using Keycloak (or any OIDC-compliant provider) for all `/tickets/` router endpoints. Healthcheck endpoints remain public.

Auth module (`app/auth.py`):
- OIDC discovery resolves JWKS URI from issuer URL automatically
- JWT validation: signature (JWKS RS256), expiration, issuer, audience, and sub claims

Docker / deployment:
- compose.yaml: fix duplicate environment key, add OIDC vars
- compose.override.yaml: dev setup with Keycloak, app volume mounts, hot-reload
- production deployment assumes host nginx in front of the API

Environment variables:
- OIDC_ISSUER_URL: Keycloak realm URL (enables auth when set)
- OIDC_AUDIENCE: expected JWT audience / client ID
- OIDC_ALGORITHMS: signing algorithms (default: RS256)